### PR TITLE
Add xdebug remote debug support

### DIFF
--- a/ansible/roles/xdebug/tasks/install.yml
+++ b/ansible/roles/xdebug/tasks/install.yml
@@ -2,3 +2,13 @@
 - name: Install xDebug
   sudo: yes
   apt: pkg=php5-xdebug state=latest
+
+- name: Capture outgoing IP address
+  shell: route | tail -n 1 | awk -F ' ' '{print $1}' | sed 's/\.0/\.1/g'
+  sudo: yes
+  register: xdebug_ip_address
+
+- name: Place xdebug configuration
+  template: src=xdebug.ini dest=/etc/php5/mods-available/xdebug.ini
+  sudo: yes
+  notify: restart apache

--- a/ansible/roles/xdebug/templates/xdebug.ini
+++ b/ansible/roles/xdebug/templates/xdebug.ini
@@ -1,0 +1,3 @@
+zend_extension=xdebug.so
+xdebug.remote_enable=On
+xdebug.remote_host={{ php.xdebug.host|default(xdebug_ip_address.stdout, true) }}

--- a/ansible/vars/default.yml
+++ b/ansible/vars/default.yml
@@ -48,6 +48,7 @@ php:
   packages: [php5-cli, php5-intl, php5-mcrypt, php5-mysql, php5-gd]
   xdebug:
     install: '1'
+    host: ~
   composer:
     install: '1'
     github_token: ~


### PR DESCRIPTION
It tries to automatically detect the host IP where
the debugger server is started. In case this automatic
detection would fail one can override this value by
providing `php.xdebug.host` configuration option.
